### PR TITLE
Updated inbound and outbound adapter documentation for servicebus

### DIFF
--- a/docs/Adapters/Inbound/service-bus.md
+++ b/docs/Adapters/Inbound/service-bus.md
@@ -58,7 +58,7 @@ A new window pops up. Add data as seen below:
 ![img](https://cmhpictsa.blob.core.windows.net/pictures/Service%20bus%20inbound%20config.png?sv=2020-08-04&st=2022-01-11T10%3A05%3A24Z&se=2040-01-12T10%3A05%3A00Z&sr=b&sp=r&sig=7Yh9XRzX%2FKF99aoiGDSFT43w9XkDUcRQwKPbufYpl60%3D)
 
 - **Polling Interval**: Dictates when files are picked from the Azure Storage account. The minimum interval allowed at this time is 60 seconds. You can specify intervals by typing in seconds.
-- **Connection String Security Configuration**: Reference to the [Security Configuration](/Security/Security-Configurations) that contains the relevant connection properties.
+- **Connection String Security Configuration**: Reference to the [Security Configuration](/Security/Security-Configurations) that contains the relevant connection properties. Note that a servicebus connection string cannot contain 'EntityPath', as this information is set in the 'Topic Name' or 'Queue Name' field.
 - **Topic Name**: The name of the topic.
 - **Subscription Name**: The name of the subscription to pick files from.
 - **Use Pure Message Sending**: Enables the [Pure Message Sending Pattern](#pure-message-sending). If kept unchecked the [Metadata on Bus, data as blob](#metadata-on-bus-data-as-blob) pattern is used.

--- a/docs/Adapters/Outbound/service-bus.md
+++ b/docs/Adapters/Outbound/service-bus.md
@@ -60,7 +60,7 @@ A new window pops up. Add data as seen below:
 
 ![img](https://cmhpictsa.blob.core.windows.net/pictures/Service%20bus%20outbound%20config.png?sv=2020-08-04&st=2022-05-02T11%3A59%3A06Z&se=2040-05-03T11%3A59%3A00Z&sr=b&sp=r&sig=cYMR8m3f2ugTGubirtHz%2BIPtARJL1YDavcCkL5MlUH8%3D)
 
-- **Connection String Security Configuration**: Reference to the [Security Configuration](/Security/Security-Configurations) that contains the relevant connection properties.
+- **Connection String Security Configuration**: Reference to the [Security Configuration](/Security/Security-Configurations) that contains the relevant connection properties. Note that a servicebus connection string cannot contain 'EntityPath', as this information is set in the 'Topic Name' or 'Queue Name' field.
 - **Adapter Name**: The logical name of the adapter. This is shown in the configuration view on close.
 - **Topic Name**: The name of the topic.
 - **Service bus message label**: The label to be added to the service bus message.


### PR DESCRIPTION
Updated inbound and outbound adapter documentation for service bus to mention that EntityPath cannot be part of the connection string when configuring the adapters